### PR TITLE
タスク一覧ページでの降順ソート, 降順ソートのテストをそれぞれ実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(id: "DESC")
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -12,9 +12,9 @@
   <tr>
     <td><%= task.title %></td>
     <td><%= task.content %></td>
-    <td><%= link_to t('view.show'), task_path(task.id) %></td>
-    <td><%= link_to t('view.edit'), edit_task_path(task.id) %></td>
-    <td><%= link_to t('view.delete'), task_path(task.id), method: :delete ,data: { confirm: t('view.confirm_delete') } %></td>
+    <td class="show"><%= link_to t('view.show'), task_path(task.id) %></td>
+    <td class="edit"><%= link_to t('view.edit'), edit_task_path(task.id) %></td>
+    <td class="delete"><%= link_to t('view.delete'), task_path(task.id), method: :delete ,data: { confirm: t('view.confirm_delete') } %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -8,8 +8,8 @@
     <th><%= t('view.content') %></th>
   </tr>
 
-<% @tasks.reverse_each do |task| %>
-  <tr>
+<% @tasks.each do |task| %>
+  <tr class="Task_content">
     <td><%= task.title %></td>
     <td><%= task.content %></td>
     <td class="show"><%= link_to t('view.show'), task_path(task.id) %></td>

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -4,14 +4,22 @@ FactoryBot.define do
     # 作成するテストデータの名前を「task」とします
     # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
     factory :task, class: Task do
-      title { "1月1日" }
-      content { "最初のコンテンツ" }
+        title { "1月1日" }
+        content { "最初のコンテンツ" }
+        #created_at { "2019-01-01 19:13:53 +0900" }
     end
   
     # 作成するテストデータの名前を「second_task」とします
     # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
     factory :second_task, class: Task do
-      title { "1月2日" }
-      content { "2番目のコンテンツ" }
+        title { "1月2日" }
+        content { "2番目のコンテンツ" }
+        #created_at { "2019-01-02 19:13:53 +0900" }
+    end
+
+    factory :third_task, class: Task do
+        title { "1月3日" }
+        content { "3番目のコンテンツ" }
+        #created_at { "2019-01-03 19:13:53 +0900" }
     end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,17 @@
+# 「FactoryBotを使用します」という記述
+FactoryBot.define do
+
+    # 作成するテストデータの名前を「task」とします
+    # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
+    factory :task, class: Task do
+      title { "1月1日" }
+      content { "最初のコンテンツ" }
+    end
+  
+    # 作成するテストデータの名前を「second_task」とします
+    # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
+    factory :second_task, class: Task do
+      title { "1月2日" }
+      content { "2番目のコンテンツ" }
+    end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "タスク管理機能", type: :feature do
     # （「タスク一覧のテスト」でも「タスクが作成日時の降順に並んでいるかのテスト」でも、background内のコードが実行される）
     FactoryBot.create(:task)
     FactoryBot.create(:second_task)
+    FactoryBot.create(:third_task)
   end
 
   scenario "タスク一覧のテスト" do
@@ -41,8 +42,8 @@ RSpec.feature "タスク管理機能", type: :feature do
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-
-    expect(Task.order("created_at DESC"))
-    #これでソートをテストしている記事を見つけたが、なぜこの記述で判定できるのか理解はできていない。
+    expect(all('.Task_content')[0]).to have_content '1月3日'
+    expect(all('.Task_content')[2]).to have_content '1月1日'
+    #これでソートをテストしている記事から引用したが、なぜこの記述で判定できるのか理解はできていない。
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,14 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
+  background do
+    # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
+
+    # backgroundの中に記載された記述は、そのカテゴリ内（feature "タスク管理機能", type: :feature do から endまでの内部）
+    # に存在する全ての処理内（scenario内）で実行される
+    # （「タスク一覧のテスト」でも「タスクが作成日時の降順に並んでいるかのテスト」でも、background内のコードが実行される）
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+  end
+
   scenario "タスク一覧のテスト" do
-    Task.create!(title: 'test_task_01', content: 'testtesttest')
-    Task.create!(title: 'test_task_02', content: 'samplesample')
-  
     visit tasks_path
   
-    expect(page).to have_content 'testtesttest'
-    expect(page).to have_content 'samplesample'
+    expect(page).to have_content '1月1日'
+    expect(page).to have_content '最初のコンテンツ'
   end
 
   scenario "タスク作成のテスト" do
@@ -23,14 +30,19 @@ RSpec.feature "タスク管理機能", type: :feature do
   end
 
   scenario "タスク詳細のテスト" do
-    Task.create!(title: 'てすとーーー', content: 'てすつ')
-  
+
     visit tasks_path
-  
-    first("table").click_link "詳細を確認する"
 
-    expect(page).to have_content 'てすとーーー'
-    expect(page).to have_content 'てすつ'
+    first(".show").click
 
+    expect(page).to have_content '1月2日'
+    expect(page).to have_content '2番目のコンテンツ'
+  end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    visit tasks_path
+
+    expect(Task.order("created_at DESC"))
+    #これでソートをテストしている記事を見つけたが、なぜこの記述で判定できるのか理解はできていない。
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
   
+
+  RSpec.configure do |config|
+    config.include FactoryBot::Syntax::Methods
+  
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.before(:all) do
+    FactoryBot.reload
+  end
+
 end


### PR DESCRIPTION
はじめはView上でreverse_eachでソートしていたが、コントローラ上でのソートに変更した。